### PR TITLE
Feature/retry policy

### DIFF
--- a/src/components/NodePropertiesEditor.css
+++ b/src/components/NodePropertiesEditor.css
@@ -147,3 +147,58 @@
   margin: 0;
   font-style: italic;
 }
+
+/* Retry Policy Styles */
+.retry-policy-item {
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 12px;
+  margin-bottom: 8px;
+  background-color: var(--surface-color);
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.no-retry-policies {
+  text-align: center;
+  padding: 1rem;
+  color: var(--text-secondary);
+}
+
+.create-retry-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border: 1px solid var(--primary-color);
+  background-color: var(--surface-color);
+  color: var(--primary-color);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 12px;
+  font-weight: 500;
+  margin: 8px auto 0;
+}
+
+.create-retry-btn:hover {
+  background-color: var(--primary-color);
+  color: white;
+}
+
+.retry-policies-management {
+  margin-top: 12px;
+}
+
+/* Enhanced form inputs for retry policies */
+.retry-policy-item .form-group input[type="number"] {
+  min-width: 0;
+}
+
+.retry-policy-item .form-row .form-group {
+  min-width: 0;
+}

--- a/src/components/NodePropertiesEditor.js
+++ b/src/components/NodePropertiesEditor.js
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { Plus, Minus, Settings } from 'lucide-react';
+import { Plus, Minus, Settings, RefreshCw } from 'lucide-react';
+import { v4 as uuidv4 } from 'uuid';
 import './NodePropertiesEditor.css';
 
-const NodePropertiesEditor = ({ node, onUpdateNodeData }) => {
+const NodePropertiesEditor = ({ node, onUpdateNodeData, workflowMetadata, onUpdateWorkflowMetadata }) => {
   const [formData, setFormData] = useState({});
 
   useEffect(() => {
@@ -173,6 +174,97 @@ const NodePropertiesEditor = ({ node, onUpdateNodeData }) => {
     onUpdateNodeData(node.id, updatedData);
   };
 
+  // Retry Policy Management
+  const getRetryPolicies = () => {
+    const policies = workflowMetadata?.retryPolicies || [];
+    // Ensure all policies have IDs (for backward compatibility)
+    let needsUpdate = false;
+    const updatedPolicies = policies.map(policy => {
+      if (!policy.id) {
+        needsUpdate = true;
+        return { ...policy, id: uuidv4() };
+      }
+      return policy;
+    });
+
+    // Update metadata if we added IDs
+    if (needsUpdate && onUpdateWorkflowMetadata) {
+      onUpdateWorkflowMetadata({
+        ...workflowMetadata,
+        retryPolicies: updatedPolicies
+      });
+    }
+
+    return updatedPolicies;
+  };
+
+  const addRetryPolicy = () => {
+    const retryPolicies = [...getRetryPolicies()];
+    const newPolicy = {
+      id: uuidv4(), // Stable unique ID
+      name: `retryPolicy${retryPolicies.length + 1}`,
+      delay: 'PT2S',
+      maxAttempts: 3,
+      increment: 'PT1S',
+      multiplier: 2.0,
+      maxDelay: 'PT30S',
+      jitter: { from: 'PT0S', to: 'PT1S' }
+    };
+    retryPolicies.push(newPolicy);
+
+    const updatedMetadata = {
+      ...workflowMetadata,
+      retryPolicies
+    };
+    onUpdateWorkflowMetadata(updatedMetadata);
+  };
+
+  const updateRetryPolicy = (policyId, field, value) => {
+    const retryPolicies = [...getRetryPolicies()];
+    const policyIndex = retryPolicies.findIndex(p => p.id === policyId);
+
+    if (policyIndex === -1) return;
+
+    if (field.includes('.')) {
+      const [parentField, childField] = field.split('.');
+      retryPolicies[policyIndex] = {
+        ...retryPolicies[policyIndex],
+        [parentField]: {
+          ...retryPolicies[policyIndex][parentField],
+          [childField]: value
+        }
+      };
+    } else {
+      retryPolicies[policyIndex] = {
+        ...retryPolicies[policyIndex],
+        [field]: value
+      };
+    }
+
+    const updatedMetadata = {
+      ...workflowMetadata,
+      retryPolicies
+    };
+    onUpdateWorkflowMetadata(updatedMetadata);
+  };
+
+  const removeRetryPolicy = (policyId) => {
+    const retryPolicies = [...getRetryPolicies()];
+    const filteredPolicies = retryPolicies.filter(p => p.id !== policyId);
+
+    const updatedMetadata = {
+      ...workflowMetadata,
+      retryPolicies: filteredPolicies
+    };
+    onUpdateWorkflowMetadata(updatedMetadata);
+  };
+
+  const handleRetryPolicyChange = (field, value) => {
+    const updatedData = { ...formData, [field]: value };
+    setFormData(updatedData);
+    onUpdateNodeData(node.id, updatedData);
+  };
+
   return (
     <div className="node-properties-editor">
       <div className="form-group">
@@ -251,6 +343,153 @@ const NodePropertiesEditor = ({ node, onUpdateNodeData }) => {
               </div>
             </div>
           ))}
+        </div>
+      )}
+
+      {node.type === 'operation' && (
+        <div className="section">
+          <div className="section-header">
+            <RefreshCw size={16} />
+            <span>Retry Policy</span>
+          </div>
+
+          <div className="form-group">
+            <label>Retry Policy</label>
+            <select
+              value={formData.retryRef || ''}
+              onChange={(e) => handleRetryPolicyChange('retryRef', e.target.value)}
+            >
+              <option value="">No retry policy</option>
+              {getRetryPolicies().map((policy) => (
+                <option key={policy.id} value={policy.id}>
+                  {policy.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {getRetryPolicies().length === 0 && (
+            <div className="no-retry-policies">
+              <p>No retry policies defined.</p>
+              <button
+                className="create-retry-btn"
+                onClick={addRetryPolicy}
+                type="button"
+              >
+                <Plus size={14} />
+                Create Retry Policy
+              </button>
+            </div>
+          )}
+
+          {getRetryPolicies().length > 0 && (
+            <div className="retry-policies-management">
+              <div className="section-header">
+                <Settings size={16} />
+                <span>Manage Retry Policies</span>
+                <button className="add-btn" onClick={addRetryPolicy}>
+                  <Plus size={14} />
+                </button>
+              </div>
+
+              {getRetryPolicies().map((policy) => (
+                <div key={policy.id} className="retry-policy-item">
+                  <div className="item-header">
+                    <span>Policy: {policy.name}</span>
+                    <button className="remove-btn" onClick={() => removeRetryPolicy(policy.id)}>
+                      <Minus size={14} />
+                    </button>
+                  </div>
+
+                  <div className="form-group">
+                    <label>Name</label>
+                    <input
+                      type="text"
+                      value={policy.name || ''}
+                      onChange={(e) => updateRetryPolicy(policy.id, 'name', e.target.value)}
+                      placeholder="Retry policy name"
+                    />
+                  </div>
+
+                  <div className="form-row">
+                    <div className="form-group">
+                      <label>Initial Delay</label>
+                      <input
+                        type="text"
+                        value={policy.delay || ''}
+                        onChange={(e) => updateRetryPolicy(policy.id, 'delay', e.target.value)}
+                        placeholder="PT2S"
+                      />
+                    </div>
+                    <div className="form-group">
+                      <label>Max Attempts</label>
+                      <input
+                        type="number"
+                        value={policy.maxAttempts || ''}
+                        onChange={(e) => updateRetryPolicy(policy.id, 'maxAttempts', parseInt(e.target.value))}
+                        placeholder="3"
+                        min="1"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="form-row">
+                    <div className="form-group">
+                      <label>Increment</label>
+                      <input
+                        type="text"
+                        value={policy.increment || ''}
+                        onChange={(e) => updateRetryPolicy(policy.id, 'increment', e.target.value)}
+                        placeholder="PT1S"
+                      />
+                    </div>
+                    <div className="form-group">
+                      <label>Multiplier</label>
+                      <input
+                        type="number"
+                        step="0.1"
+                        value={policy.multiplier || ''}
+                        onChange={(e) => updateRetryPolicy(policy.id, 'multiplier', parseFloat(e.target.value))}
+                        placeholder="2.0"
+                        min="1"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="form-group">
+                    <label>Max Delay</label>
+                    <input
+                      type="text"
+                      value={policy.maxDelay || ''}
+                      onChange={(e) => updateRetryPolicy(policy.id, 'maxDelay', e.target.value)}
+                      placeholder="PT30S"
+                    />
+                  </div>
+
+                  <div className="form-row">
+                    <div className="form-group">
+                      <label>Jitter From</label>
+                      <input
+                        type="text"
+                        value={policy.jitter?.from || ''}
+                        onChange={(e) => updateRetryPolicy(policy.id, 'jitter.from', e.target.value)}
+                        placeholder="PT0S"
+                      />
+                    </div>
+                    <div className="form-group">
+                      <label>Jitter To</label>
+                      <input
+                        type="text"
+                        value={policy.jitter?.to || ''}
+                        onChange={(e) => updateRetryPolicy(policy.id, 'jitter.to', e.target.value)}
+                        placeholder="PT1S"
+                      />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -33,6 +33,8 @@ const Sidebar = ({
   onRedo,
   canUndo,
   canRedo,
+  workflowMetadata,
+  onUpdateWorkflowMetadata,
 }) => {
   const [activeTab, setActiveTab] = useState('palette');
   const [lastSaved, setLastSaved] = useState(null);
@@ -247,7 +249,12 @@ const Sidebar = ({
               </button>
             </div>
 
-            <NodePropertiesEditor node={selectedNode} onUpdateNodeData={onUpdateNodeData} />
+            <NodePropertiesEditor
+              node={selectedNode}
+              onUpdateNodeData={onUpdateNodeData}
+              workflowMetadata={workflowMetadata}
+              onUpdateWorkflowMetadata={onUpdateWorkflowMetadata}
+            />
           </div>
         )}
 

--- a/src/components/WorkflowEditor.js
+++ b/src/components/WorkflowEditor.js
@@ -602,6 +602,8 @@ function WorkflowEditor() {
         onRedo={handleRedo}
         canUndo={canUndo}
         canRedo={canRedo}
+        workflowMetadata={workflowMetadata}
+        onUpdateWorkflowMetadata={setWorkflowMetadata}
       />
 
       {showJsonExporter && (
@@ -630,6 +632,7 @@ function getDefaultNodeData(type) {
             },
           },
         ],
+        retryRef: '', // Reference to retry policy
       };
     case 'switch':
       return {

--- a/src/components/WorkflowEditor.js
+++ b/src/components/WorkflowEditor.js
@@ -607,7 +607,12 @@ function WorkflowEditor() {
       />
 
       {showJsonExporter && (
-        <JsonExporter nodes={nodes} edges={edges} onClose={() => setShowJsonExporter(false)} />
+        <JsonExporter
+          nodes={nodes}
+          edges={edges}
+          workflowMetadata={workflowMetadata}
+          onClose={() => setShowJsonExporter(false)}
+        />
       )}
 
       {showJsonImporter && (


### PR DESCRIPTION
This pull request introduces support for retry policies in the workflow editor, including their creation, management, and integration into JSON import/export functionality. The changes span multiple components and include enhancements to the user interface, data handling, and workflow metadata.

### Retry Policy Integration

* **Added retry policy support in `JsonExporter`**:
  - Updated `JsonExporter` to include `workflowMetadata` as a parameter and export retry policies in the Serverless Workflow format. [[1]](diffhunk://#diff-f4d6f3a99f39d22f68f824e96efaf13409767deeaa991e73987c0e70ccc0f6c6L5-R5) [[2]](diffhunk://#diff-f4d6f3a99f39d22f68f824e96efaf13409767deeaa991e73987c0e70ccc0f6c6L32-R32) [[3]](diffhunk://#diff-f4d6f3a99f39d22f68f824e96efaf13409767deeaa991e73987c0e70ccc0f6c6R44-R52)
  - Enhanced `convertNodeToState` to add retry policy references to nodes when applicable. [[1]](diffhunk://#diff-f4d6f3a99f39d22f68f824e96efaf13409767deeaa991e73987c0e70ccc0f6c6L165-R174) [[2]](diffhunk://#diff-f4d6f3a99f39d22f68f824e96efaf13409767deeaa991e73987c0e70ccc0f6c6R190-R197)

* **Enhanced `JsonImporter` to handle retry policies**:
  - Introduced UUID-based IDs for retry policies during import and passed them as part of `workflowMetadata`. [[1]](diffhunk://#diff-9d298a33d4f8ea7c8e406f85dc063cdb02e610bf2de073472bda95acd9e6c1fdR3) [[2]](diffhunk://#diff-9d298a33d4f8ea7c8e406f85dc063cdb02e610bf2de073472bda95acd9e6c1fdR21-R40)
  - Updated `convertWorkflowToReactFlow` and `convertStateToNodeData` to map retry policy references by ID. [[1]](diffhunk://#diff-9d298a33d4f8ea7c8e406f85dc063cdb02e610bf2de073472bda95acd9e6c1fdL220-R252) [[2]](diffhunk://#diff-9d298a33d4f8ea7c8e406f85dc063cdb02e610bf2de073472bda95acd9e6c1fdL242-R274) [[3]](diffhunk://#diff-9d298a33d4f8ea7c8e406f85dc063cdb02e610bf2de073472bda95acd9e6c1fdL455-R499)

### User Interface Enhancements

* **Improved `NodePropertiesEditor` for retry policy management**:
  - Added a new section to allow users to select, create, update, and delete retry policies. [[1]](diffhunk://#diff-39240f4f5a0c87e05d7f232f36911e70c87d4bdbb7cb3f54848149dacdf74292R177-R267) [[2]](diffhunk://#diff-39240f4f5a0c87e05d7f232f36911e70c87d4bdbb7cb3f54848149dacdf74292R349-R495)
  - Ensured backward compatibility by generating IDs for existing policies without them.

* **Updated styles in `NodePropertiesEditor.css`**:
  - Added styles for retry policy management, including form rows, buttons, and policy items.

### Workflow Editor Integration

* **Integrated retry policies into `WorkflowEditor`**:
  - Passed `workflowMetadata` and its update handler to `Sidebar`, `JsonExporter`, and `JsonImporter`. [[1]](diffhunk://#diff-1a767e300053b17c9c1793fb47f51cf6fec20f2ac5bc18f2db47fe3fb5f2b2c2R605-R615) [[2]](diffhunk://#diff-1a767e300053b17c9c1793fb47f51cf6fec20f2ac5bc18f2db47fe3fb5f2b2c2R640)
  - Added a `retryRef` field to default operation node data.

### Sidebar and Node Properties

* **Extended `Sidebar` to support retry policies**:
  - Passed `workflowMetadata` and its update handler to `NodePropertiesEditor`. [[1]](diffhunk://#diff-b2415db1fb43f1726a88845570f8db1a75ae284c1b612163c72280c92761e765R36-R37) [[2]](diffhunk://#diff-b2415db1fb43f1726a88845570f8db1a75ae284c1b612163c72280c92761e765L250-R257)